### PR TITLE
Add support for MIST v2.5 tracks and BCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Manifest.toml
 .ipynb_checkpoints
 
 examples/results
+examples/old
 examples/*.html
 examples/*.pdf
 

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ArgCheck = "2"
-BolometricCorrections = "0.1.5"
+BolometricCorrections = "0.2"
 CSV = "0.10"
 CairoMakie = "0.15"
 DataInterpolations = "8"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SFHWorkflows.jl
-[StarFormationHistories.jl](https://github.com/cgarling/StarFormationHistories.jl) contains highly modular components for measuring resolved star formation histories from high-precision color magnitude diagrams. This package provides standardized workflows for making these measurements that can be configured and ran from simple YAML configuration files.
+[StarFormationHistories.jl](https://github.com/cgarling/StarFormationHistories.jl) contains highly modular components for measuring resolved star formation histories from high-precision color magnitude diagrams. This package provides standardized workflows for making these measurements that can be configured and ran from simple YAML configuration files. Users may also be interested in [BolometricCorrections.jl](https://github.com/cgarling/BolometricCorrections.jl) and [StellarTracks.jl](https://github.com/cgarling/StellarTracks.jl) which are used to interpolate isochrones on the fly for use in the SFH fitting procedure.
 
 ## Installation
 This package is registered to the Julia General Registry and can be installed via the package manager with

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -36,7 +36,8 @@ stellartracks:
   # "mist" is deprecated as of v1.1.0; use "mistv1" for MIST v1.2 or "mistv2" for MIST v2.5.
   # parsec takes no arguments. 
   # mistv1 takes vvcrit argument, either 0.0 (non-rotating) or 0.4 (rotating).
-  # mistv2 takes vvcrit (0.0 or 0.4) and alpha_fe ([α/Fe], default 0.0).
+  # mistv2 takes vvcrit (0.0 or 0.4) and alpha_fe ([α/Fe], default 0.0; supported values are
+  # −0.2, 0.0, 0.2, 0.4, 0.6).
   # bastiv2 takes several arguments, for valid options see https://cgarling.github.io/StellarTracks.jl/stable
   # alpha_fe: [alpha/Fe], default 0.0
   # canonical: Whether to use models with convective overshooting (false) or without (true), default false

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -31,10 +31,12 @@ binaries:
 
 stellartracks:
   # One entry per stellar track library you want to run the SFH fit with.
-  # Name either parsec, mist, bastiv1, bastiv2 (case insensitive).
-  # Use of bastiv1 (old basti models) is discouraged. 
+  # Name either parsec, mistv1, mistv2, bastiv1, bastiv2 (case insensitive).
+  # Use of bastiv1 (old basti models) is discouraged.
+  # "mist" is deprecated as of v1.1.0; use "mistv1" for MIST v1.2 or "mistv2" for MIST v2.5.
   # parsec takes no arguments. 
-  # mist takes vvcrit argument, either 0.0 (non-rotating) or 0.4 (rotating).
+  # mistv1 takes vvcrit argument, either 0.0 (non-rotating) or 0.4 (rotating).
+  # mistv2 takes vvcrit (0.0 or 0.4) and alpha_fe ([α/Fe], default 0.0).
   # bastiv2 takes several arguments, for valid options see https://cgarling.github.io/StellarTracks.jl/stable
   # alpha_fe: [alpha/Fe], default 0.0
   # canonical: Whether to use models with convective overshooting (false) or without (true), default false
@@ -44,9 +46,13 @@ stellartracks:
   track1:
     name: PARSEC
   track2:
-    name: MIST
+    name: MISTv1
     vvcrit: 0.0
-  track3: 
+  track3:
+    name: MISTv2
+    vvcrit: 0.0
+    alpha_fe: 0.0
+  track4: 
     name: BASTIV2
     alpha_fe: 0.0
     canonical: false
@@ -61,11 +67,15 @@ stellartracks:
 bolometriccorrections:
 # The SFH will be measured for each combination of track (defined above) and bolometric correction library (defined here)
 # See documentation https://cgarling.github.io/BolometricCorrections.jl/stable/ for names of available filtersets
+# "mist" is deprecated as of v1.1.0; use "mistv1" for MIST v1.2 or "mistv2" for MIST v2.5.
   bc1: 
     name: YBC
     filterset: acs_wfc
   bc2: 
-    name: MIST
+    name: MISTv1
+    filterset: acs_wfc
+  bc3:
+    name: MISTv2
     filterset: acs_wfc
 
 properties:

--- a/examples/fit_sfh.jl
+++ b/examples/fit_sfh.jl
@@ -13,8 +13,25 @@ import YAML
 galaxy_name = "Aquarius"
 
 # Here we'll parse the x-axis color label and y-axis magnitude label from the provided config.
-# You can also just hard-code it if you want.
-dict = YAML.load_file(config) # Load config into dictionary so we can access filter names
+# You can also just hard-code it if you want. By default YAML.load_file(file) loads into a
+# basic dictionary (Dict) which does not preserve insertion order; we will use the
+# OrderedDict from the OrderedCollections.jl package so that insertion order is preserved
+# and the keys of `dict` below will be in the same order they appear in the actual config file
+dicttype = Dict{String, Any} # Set fallback as standard dict, overwritten if OrderedCollections.jl cannot be installed
+try
+    using OrderedCollections: OrderedDict
+    global dicttype = OrderedDict{String, Any}
+catch e1
+    try
+        import Pkg
+        Pkg.add("OrderedCollections")
+        using OrderedCollections: OrderedDict
+        global dicttype = OrderedDict{String, Any}
+    catch e2
+        @warn "Error loading OrderedCollections.jl, using standard Dict instead, which does not preserve insertion order."
+    end
+end
+dict = YAML.load_file(config; dicttype=dicttype) # Load config into dictionary so we can access filter names
 xcolor = split(dict["data"]["binning"]["xcolor"], ",")
 xcolor = join(strip_whitespace.(xcolor), " - ") # creates a string like "F475W - F814W" 
 yfilter = dict["data"]["binning"]["yfilter"]    # creates a string like "F814W"

--- a/src/SFH/Parsing.jl
+++ b/src/SFH/Parsing.jl
@@ -7,8 +7,8 @@ import YAML
 using OrderedCollections: OrderedDict
 using InitialMassFunctions
 using StarFormationHistories: NoBinaries, RandomBinaryPairs, MH_from_Z, dMH_dZ, PowerLawMZR, LinearAMR, LogarithmicAMR, GaussianDispersion
-using StellarTracks: PARSECLibrary, MISTLibrary, BaSTIv1Library, BaSTIv2Library
-using BolometricCorrections: YBCGrid, MISTBCGrid
+using StellarTracks: PARSECLibrary, MISTv1Library, MISTv2Library, BaSTIv1Library, BaSTIv2Library
+using BolometricCorrections: YBCGrid, MISTv1BCGrid, MISTv2BCGrid
 
 strip_whitespace(s::AbstractString) = replace(s, r"\s+" => "")
 
@@ -66,16 +66,24 @@ function parse_tracks(dict)
         goodkeys = sort([key for key in keys(st) if occursin("track", key)])
         return [parse_tracks(st[key]) for key in goodkeys]
     end
-    valid_models = ("parsec", "mist", "bastiv1", "bastiv2")
+    valid_models = ("parsec", "mistv1", "mistv2", "bastiv1", "bastiv2")
     name = lowercase(dict["name"])
+    if name == "mist"
+        @warn "Stellar track name \"mist\" is deprecated; please use \"mistv1\" for MIST v1.2 or \"mistv2\" for MIST v2.5. Assuming \"mistv1\"."
+        name = "mistv1"
+    end
     if !(name ∈ valid_models)
         error("Stellar track model $name invalid; valid stellar track models are $(join(valid_models, ", ")).")
     end
     if name == "parsec"
         return PARSECLibrary()
-    elseif name == "mist"
+    elseif name == "mistv1"
         vvcrit = get(dict, "vvcrit", 0.0)
-        return MISTLibrary(vvcrit)
+        return MISTv1Library(vvcrit)
+    elseif name == "mistv2"
+        vvcrit = get(dict, "vvcrit", 0.0)
+        afe = get(dict, "alpha_fe", 0.0)::Float64
+        return MISTv2Library(vvcrit, afe)
     elseif name == "bastiv1"
         α_fe = get(dict, "alpha_fe", 0.0)::Float64
         canonical = get(dict, "canonical", false)::Bool
@@ -98,10 +106,14 @@ function parse_bcs(dict)
         bc = dict["bolometriccorrections"]
         return [parse_bcs(bc[key]) for key in keys(bc)]
     end
-    valid_models = ("ybc", "mist")
+    valid_models = ("ybc", "mistv1", "mistv2")
     name = lowercase(dict["name"])
+    if name == "mist"
+        @warn "Bolometric correction name \"mist\" is deprecated; please use \"mistv1\" for MIST v1.2 or \"mistv2\" for MIST v2.5. Assuming \"mistv1\"."
+        name = "mistv1"
+    end
     if !(name ∈ valid_models)
-        error("Bolometric correction grid $name invalid; valid BC grids are are $(join(valid_models, ", ")).")
+        error("Bolometric correction grid $name invalid; valid BC grids are $(join(valid_models, ", ")).")
     end
     filterset = dict["filterset"]
     return if name == "ybc"
@@ -111,11 +123,18 @@ function parse_bcs(dict)
             println("Failed to initialize YBC bolometric correction grid with filterset $filterset; error shown below")
             rethrow(e)
         end
-    elseif name == "mist"
+    elseif name == "mistv1"
         try
-            MISTBCGrid(filterset)
+            MISTv1BCGrid(filterset)
         catch e
-            println("Failed to initialize MIST bolometric correction grid with filterset $filterset; error shown below")
+            println("Failed to initialize MIST v1.2 bolometric correction grid with filterset $filterset; error shown below")
+            rethrow(e)
+        end
+    elseif name == "mistv2"
+        try
+            MISTv2BCGrid(filterset)
+        catch e
+            println("Failed to initialize MIST v2.5 bolometric correction grid with filterset $filterset; error shown below")
             rethrow(e)
         end
     end

--- a/src/SFH/Systematics.jl
+++ b/src/SFH/Systematics.jl
@@ -6,7 +6,7 @@ export systematics, mag_select
 import StarFormationHistories as SFH
 import CSV
 using TypedTables: Table, columnnames, getproperties
-using BolometricCorrections: chemistry, MH, Z, filternames, AbstractBCGrid, AbstractBCTable, MISTBCGrid, gridname
+using BolometricCorrections: chemistry, MH, Z, filternames, AbstractBCGrid, AbstractBCTable, gridname
 using StellarTracks: AbstractTrackLibrary, isochrone
 using ArgCheck: @argcheck
 using Printf: @printf, @sprintf, Format, format
@@ -23,26 +23,52 @@ convert_MH(mh, tracks, bcs) = MH(chemistry(bcs), Z(chemistry(tracks), mh))
 
 """
     (xidx, yidxs) = mag_select(bcgrid::AbstractBCGrid, ystring::Union{AbstractString, Symbol}, xstrings)
-Returns the indices into `filternames(bcgrid)` that correspond to the provided `ystring` and `xstrings` arguments. 
+Returns the keys into `filternames(bcgrid)` as `Symbol`s that correspond to the provided `ystring` and `xstrings` arguments. 
 Used to programmatically determine the proper columns to select from an `AbstractBCGrid` using user-specific filter names.
-```jldoctest
-julia> using BolometricCorrections: MISTBCGrid, filternames
 
-julia> m = MISTBCGrid("hst_acs_wfc")
+```jldoctest mag_select
+julia> using SFHWorkflows.SFHFitting.Systematics: mag_select
+
+julia> using BolometricCorrections: MISTv1BCGrid, filternames
+
+julia> m = MISTv1BCGrid("JWST")
 
 julia> mag_select(m, "F150W", (:F090W, :F150W))
-(6, [2, 6])
+(:F150W, (:F090W, :F150W))
+```
+
+Some BC grids have known idiosyncrasies in their filter naming that can cause problems. For example, the "JWST" filter system in MISTv2 has filters prefixed with "NIRCAM_", which can cause problems with the matching. The `mag_select` function includes some manual overrides for known cases like this, but if you have a BC grid with non-standard filter names that causes problems, please open an issue or submit a PR to add a manual override for your specific case.
+
+```jldoctest mag_select
+julia> using BolometricCorrections: MISTv2BCGrid
+
+julia> mv2 = MISTv2BCGrid("JWST")
+
+julia> mag_select(mv2, "F150W", (:F090W, :F150W))
+(:NIRCAM_F150W, (:NIRCAM_F090W, :NIRCAM_F150W))
 ```
 """
 function mag_select(bcgrid::Union{AbstractBCGrid, AbstractBCTable}, ystring::Union{AbstractString, Symbol}, xstrings)
+
+    # Some BC grids have non-standard filter names that cause problems trying to match the same filter strings
+    # across multiple BCs. An example is JWST in MISTv2, which prefixes all filters like NIRCAM_F150W, so if you
+    # specify "F150W" as the ystring, it is ambiguous to match between "NIRCAM_F150W" and "NIRCAM_F150W2". 
+    # Here we will provide some manual overrides for known cases.
+    function normalize_filter(filt)
+        filt = string(filt)
+        if startswith(filt, "NIRCAM_")
+            return replace(filt, "NIRCAM_" => "")
+        else
+            return filt
+        end
+    end
+
     @argcheck length(xstrings) == 2
     Base.require_one_based_indexing(xstrings)
-    # ystring = lowercase(string(ystring))
-    # xstrings = [lowercase(string(xs)) for xs in xstrings]
-    # filters = [lowercase(string(f)) for f in filternames(bcgrid)]
     ystring = string(ystring)
     xstrings = [string(xs) for xs in xstrings]
-    filters = [string(f) for f in filternames(bcgrid)]
+    original_filters = [string(f) for f in filternames(bcgrid)] # Need to keep these as these are what we eventually want to return
+    filters = normalize_filter.(original_filters) # Apply normalization to filter names for matching
     ymatches = findfirst(==(ystring), filters)
     if !isnothing(ymatches) # Look for exact match first
         yidx = ymatches
@@ -75,7 +101,7 @@ function mag_select(bcgrid::Union{AbstractBCGrid, AbstractBCTable}, ystring::Uni
         end      
     end
     # return yidx, xidxs
-    return Symbol(filters[yidx]), (Symbol(filters[xidxs[1]]), Symbol(filters[xidxs[2]]))
+    return Symbol(original_filters[yidx]), (Symbol(original_filters[xidxs[1]]), Symbol(original_filters[xidxs[2]]))
 end
 
 function templates(tracklib::AbstractTrackLibrary, bclib::AbstractBCGrid,
@@ -108,34 +134,16 @@ function templates(tracklib::AbstractTrackLibrary, bclib::AbstractBCGrid,
 
     # @threads for (i, (mh, logage)) in collect(enumerate(Iterators.product(unique_MH, unique_logAge))) # issorted(mdf_template_logAge) == true
     Threads.@threads for i in eachindex(unique_MH)
-    # for i in eachindex(unique_MH)
         mh = unique_MH[i]
         # Deal with MH outside range of tracklib
-        if (mh < minimum(MH(tracklib)))
-            tracklib_mh = minimum(MH(tracklib))
-        elseif (mh > maximum(MH(tracklib)))
-            tracklib_mh = maximum(MH(tracklib))
-        else
-            tracklib_mh = mh
-        end
-        # # Deal with MH outside range of bclib
-        # if (mh < minimum(MH(bclib)))
-        #     bclib_mh = minimum(MH(bclib))
-        # elseif (mh > maximum(MH(bclib)))
-        #     bclib_mh = maximum(MH(bclib))
-        # else
-        #     bclib_mh = mh
-        # end
-        # bct = bclib(bclib_mh) 
-        # Interpolate bclib at correct MH, Av
-        bct = bclib(unique_bc_MH[i], Av)
+        tracklib_mh = clamp(mh, extrema(MH(tracklib))...)
+        # bclib_mh = clamp(unique_bc_MH[i], extrema(MH(bclib))...)
 
         Threads.@threads for j in eachindex(unique_logAge)
-        # for j in eachindex(unique_logAge)
             logage = unique_logAge[j]
             ind = j + ((i-1) * length(unique_logAge)) # index into templates and other buffers for (i,j)
-            iso = isochrone(tracklib, bct, logage, tracklib_mh)
-            iso_mags = [getproperty(iso, k) for k in iso_symb] # (xsymb, ysymbs...)]
+            iso = isochrone(tracklib, bclib, logage, tracklib_mh, Av)
+            iso_mags = [getproperty(iso, k) for k in iso_symb]
             m_ini = iso.m_ini
             templates[ind] = SFH.partial_cmd_smooth(m_ini, iso_mags, err_funcs, yidx, xidxs, imf, 
                                                     complete_funcs, bias_funcs; 


### PR DESCRIPTION
MIST v2.5 supports alpha-enhanced chemical mixtures. These are already implemented in StellarTracks.jl v1.1.0 and BolometricCorrections.jl v0.2. This PR allows access to these new models through SFHWorkflows.jl.

This is non-breaking as the old "mist" identifiers (for both tracks and BCs) now alias to "mistv1" and the MIST v2.5 models can be selected with "mistv2". A deprecation warning is printed when specifying "mist" as "mistv1" is now preferred. 

There are some idiosyncrasies in the filter name conventions in MIST v2.5; for example, for the "JWST" filter system all filter names are prefixed with "NIRCAM_". This can mess with the logic of `mag_select` so I added an additional `normalize_filter` function that can be extended when problematic filter sets are identified.